### PR TITLE
Avoid dictionary errors, augment search algorithm.

### DIFF
--- a/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
+++ b/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
@@ -128,7 +128,9 @@ namespace McMaster.NETCore.Plugins.Loader
         {
             ValidateRelativePath(library.AdditionalProbingPath);
 
-            _managedLibraries.Add(library.Name.Name, library);
+            if (!_managedLibraries.ContainsKey(library.Name.Name))
+                _managedLibraries.Add(library.Name.Name, library);
+
             return this;
         }
 
@@ -142,7 +144,9 @@ namespace McMaster.NETCore.Plugins.Loader
             ValidateRelativePath(library.AppLocalPath);
             ValidateRelativePath(library.AdditionalProbingPath);
 
-            _nativeLibraries.Add(library.Name, library);
+            if (!_nativeLibraries.ContainsKey(library.Name))
+                _nativeLibraries.Add(library.Name, library);
+
             return this;
         }
 

--- a/src/Plugins/Loader/ManagedLoadContext.cs
+++ b/src/Plugins/Loader/ManagedLoadContext.cs
@@ -157,6 +157,19 @@ namespace McMaster.NETCore.Plugins.Loader
                 }
             }
 
+            // 3. Search in _basePath/runtimes
+            if (library.AdditionalProbingPath.StartsWith(library.Name.Name, StringComparison.OrdinalIgnoreCase) &&
+                library.AdditionalProbingPath.Contains("runtimes"))
+            {
+                var postPackageSpecProbingPath = library.AdditionalProbingPath.Substring(library.AdditionalProbingPath.IndexOf("runtimes"));
+                var candidate = Path.Combine(_basePath, postPackageSpecProbingPath);
+                if (File.Exists(candidate))
+                {
+                    path = candidate;
+                    return true;
+                }
+            }
+
             path = null;
             return false;
         }


### PR DESCRIPTION
With these minor alterations I was able to use DotNetCorePlugins to get an MsBuild PowerShellTaskFactory working on .NET core.