### PR TITLE
Issue #27: Workaround normalizing paths when loading native assets

### DIFF
--- a/releasenotes.props
+++ b/releasenotes.props
@@ -5,6 +5,7 @@
 Bug fix:
 * Fix loading plugins which use SqlClient on Windows.
 * Fallback to loading assemblies from the plugin base directory when all else fails.
+* Normalize paths before loading native assets to workaround bug in .NET Core 2.x.
 ]]>
     </PackageReleaseNotes>
     <PackageReleaseNotes Condition="'$(VersionPrefix)' == '0.2.1'">

--- a/src/Plugins/Loader/ManagedLoadContext.cs
+++ b/src/Plugins/Loader/ManagedLoadContext.cs
@@ -130,7 +130,7 @@ namespace McMaster.NETCore.Plugins.Loader
                 {
                     if (SearchForLibrary(library, prefix, out var path))
                     {
-                        return LoadUnmanagedDllFromPath(path);
+                        return LoadUnmanagedDllFromResolvedPath(path);
                     }
                 }
                 else
@@ -153,7 +153,7 @@ namespace McMaster.NETCore.Plugins.Loader
                         {
                             if (SearchForLibrary(library, prefix, out var path))
                             {
-                                return LoadUnmanagedDllFromPath(path);
+                                return LoadUnmanagedDllFromResolvedPath(path);
                             }
                         }
                         else
@@ -162,13 +162,13 @@ namespace McMaster.NETCore.Plugins.Loader
                             var localFile = Path.Combine(_basePath, prefix + unmanagedDllName + suffix);
                             if (File.Exists(localFile))
                             {
-                                return LoadUnmanagedDllFromPath(localFile);
+                                return LoadUnmanagedDllFromResolvedPath(localFile);
                             }
 
                             var localFileWithoutSuffix = Path.Combine(_basePath, prefix + unmanagedDllName);
                             if (File.Exists(localFileWithoutSuffix))
                             {
-                                return LoadUnmanagedDllFromPath(localFileWithoutSuffix);
+                                return LoadUnmanagedDllFromResolvedPath(localFileWithoutSuffix);
                             }
                         }
                     }
@@ -249,6 +249,12 @@ namespace McMaster.NETCore.Plugins.Loader
 
             path = null;
             return false;
+        }
+
+        private IntPtr LoadUnmanagedDllFromResolvedPath(string unmanagedDllPath)
+        {
+            var normalized = Path.GetFullPath(unmanagedDllPath);
+            return LoadUnmanagedDllFromPath(normalized);
         }
     }
 }


### PR DESCRIPTION
Workaround for #27.

Note though that it doesn't include any new tests. I've run all current tests successfully, but the only verification I have time to provide is the regression test [here](https://github.com/natemcmaster/DotNetCorePlugins/issues/27#issuecomment-456466985).