### PR TITLE
Allow loading assembly by path

### DIFF
--- a/src/Plugins/PluginLoader.cs
+++ b/src/Plugins/PluginLoader.cs
@@ -175,6 +175,14 @@ namespace McMaster.NETCore.Plugins
         }
 
         /// <summary>
+        /// Load an assembly from path.
+        /// </summary>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <returns>The assembly.</returns>
+        public Assembly LoadAssemblyFromPath(string assemblyPath)
+            => _context.LoadFromAssemblyPath(assemblyPath);
+
+        /// <summary>
         /// Load an assembly by name.
         /// </summary>
         /// <param name="assemblyName">The assembly name.</param>


### PR DESCRIPTION
This PR exposes the `AssemblyLoadContext.LoadFromAssemblyPath` method on the `PluginLoader` interface.