### PR TITLE
Allow registering the same library multiple times

### DIFF
--- a/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
+++ b/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
@@ -148,6 +148,9 @@ namespace McMaster.NETCore.Plugins.Loader
         /// <returns>The builder.</returns>
         public AssemblyLoadContextBuilder AddManagedLibrary(ManagedLibrary library)
         {
+            if (_managedLibraries.ContainsKey(library.Name.Name))
+                return this;
+
             ValidateRelativePath(library.AdditionalProbingPath);
 
             _managedLibraries.Add(library.Name.Name, library);


### PR DESCRIPTION
In some cases a library might get registered in the `AssemblyLoadContextBuilder` multiple times. Currently the builder throws a `System.ArgumentException` (An item with the same key has already been added.) for this. (See for example https://github.com/specsolutions/deveroom-visualstudio/issues/32). 

This is a simple fix that skips the repeated registrations.