### PR TITLE
Update DependencyModel and System.Text.Json to Core 3.0 Preview 7

### DIFF
--- a/src/Plugins/Loader/RuntimeConfigExtensions.cs
+++ b/src/Plugins/Loader/RuntimeConfigExtensions.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace McMaster.NETCore.Plugins.Loader
 {
@@ -116,7 +115,7 @@ namespace McMaster.NETCore.Plugins.Loader
             try
             {
                 var file = File.ReadAllBytes(path);
-                return JsonSerializer.Parse<RuntimeConfig>(file, _serializerOptions);
+                return JsonSerializer.Deserialize<RuntimeConfig>(file, _serializerOptions);
             }
             catch
             {

--- a/src/Plugins/McMaster.NETCore.Plugins.csproj
+++ b/src/Plugins/McMaster.NETCore.Plugins.csproj
@@ -16,9 +16,9 @@ This package should be used by the host application which needs to load plugins.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0-preview6-27804-01" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview6-27804-01" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0-preview6.19303.8" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0-preview7-27912-14" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview7-27912-14" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0-preview7.19362.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates the dependencies from https://github.com/natemcmaster/DotNetCorePlugins/pull/49 to their newest counterparts, released ~2 hours ago.

It should be noted that there have been some silent API changes to `System.Text.Json` that are not mentioned in the announcement of Preview 7: https://devblogs.microsoft.com/dotnet/announcing-net-core-3-0-preview-7/

In that regard, the source was adjusted accordingly and all tests re-ran in the same configurations and newest runtime as in #49 .
