### PR TITLE
Support of hosted environments

### DIFF
--- a/src/Plugins/Loader/DependencyContextExtensions.cs
+++ b/src/Plugins/Loader/DependencyContextExtensions.cs
@@ -105,7 +105,7 @@ namespace McMaster.NETCore.Plugins.Loader
         /// <returns>The builder.</returns>
         public static AssemblyLoadContextBuilder AddDependencyContext(this AssemblyLoadContextBuilder builder, DependencyContext dependencyContext)
         {
-            var ridGraph = dependencyContext.RuntimeGraph.Any()
+            var ridGraph = dependencyContext.RuntimeGraph.Any() || DependencyContext.Default == null
                ? dependencyContext.RuntimeGraph
                : DependencyContext.Default.RuntimeGraph;
 


### PR DESCRIPTION
Microsoft.Extensions.DependencyModel.DependencyContext.Default was null in CoreCLR hosted environments (CoreCLR hosted in native app). The reason is that System.Reflection.Assembly.GetEntryAssembly() is null