### PR TITLE
Feature: add API for contextual reflection

### DIFF
--- a/src/Plugins/PluginLoader.cs
+++ b/src/Plugins/PluginLoader.cs
@@ -329,6 +329,18 @@ namespace McMaster.NETCore.Plugins
             return LoadAssembly(new AssemblyName(assemblyName));
         }
 
+#if NETCOREAPP3_0
+        /// <summary>
+        /// Sets the scope used by some System.Reflection APIs which might trigger assembly loading.
+        /// <para>
+        /// See https://github.com/dotnet/coreclr/blob/v3.0.0/Documentation/design-docs/AssemblyLoadContext.ContextualReflection.md for more details.
+        /// </para>
+        /// </summary>
+        /// <returns></returns>
+        public AssemblyLoadContext.ContextualReflectionScope EnterContextualReflection()
+            => _context.EnterContextualReflection();
+#endif
+
         /// <summary>
         /// Disposes the plugin loader. This only does something if <see cref="IsUnloadable" /> is true.
         /// When true, this will unload assemblies which which were loaded during the lifetime

--- a/src/Plugins/PublicAPI.Unshipped.txt
+++ b/src/Plugins/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-
+McMaster.NETCore.Plugins.PluginLoader.EnterContextualReflection() -> System.Runtime.Loader.AssemblyLoadContext.ContextualReflectionScope


### PR DESCRIPTION

Sometimes you may want to use a plugin along with reflection APIs such as `Type.GetType(string typeName)` or `Assembly.Load(string assemblyString)`. Depending on where these APIs are used, they might fail to load the assemblies in your plugin. In .NET Core 3+, there is an API which you can use to set the _ambient context_ which .NET's reflection APIs will use to load the correct assemblies from your plugin.

Example:
```c#
var loader = PluginLoader.CreateFromAssemblyFile("./plugins/MyPlugin/MyPlugin1.dll");
using (loader.EnterContextualReflection())
{
    var myPluginType = Type.GetType("MyPlugin.PluginClass");
    var myPluginAssembly = Assembly.Load("MyPlugin1");
}
```

Read [this post written by .NET Core engineers](https://github.com/dotnet/coreclr/blob/v3.0.0/Documentation/design-docs/AssemblyLoadContext.ContextualReflection.md) for even more details on contextual reflection.