### PR TITLE
Feature: add IMvcBuilder.AddPluginLoader

### DIFF
--- a/src/Plugins.Mvc/MvcPluginExtensions.cs
+++ b/src/Plugins.Mvc/MvcPluginExtensions.cs
@@ -13,7 +13,11 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class MvcPluginExtensions
     {
         /// <summary>
-        /// Loads
+        /// Loads controllers and razor pages from a plugin assembly.
+        /// <para>
+        /// This creates a loader with <see cref="PluginConfig.PreferSharedTypes" /> set to <c>true</c>.
+        /// If you need more control over shared types, use <see cref="AddPluginLoader" /> instead.
+        /// </para>
         /// </summary>
         /// <param name="mvcBuilder">The MVC builder</param>
         /// <param name="assemblyFile">Full path the main .dll file for the plugin.</param>
@@ -26,7 +30,24 @@ namespace Microsoft.Extensions.DependencyInjection
                     // this ensures that the version of MVC is shared between this app and the plugin
                     config.PreferSharedTypes = true);
 
-            var pluginAssembly = plugin.LoadDefaultAssembly();
+            return mvcBuilder.AddPluginLoader(plugin);
+        }
+
+        /// <summary>
+        /// Loads controllers and razor pages from a plugin loader.
+        /// <para>
+        /// In order for this to work, the PluginLoader instance must be configured to share the types
+        /// <see cref="ProvideApplicationPartFactoryAttribute" /> and <see cref="RelatedAssemblyAttribute" />
+        /// (comes from Microsoft.AspNetCore.Mvc.Core.dll). The easiest way to ensure that is done correctly
+        /// is to set <see cref="PluginConfig.PreferSharedTypes" /> to <c>true</c>.
+        /// </para>
+        /// </summary>
+        /// <param name="mvcBuilder">The MVC builder</param>
+        /// <param name="pluginLoader">An instance of PluginLoader.</param>
+        /// <returns>The builder</returns>
+        public static IMvcBuilder AddPluginLoader(this IMvcBuilder mvcBuilder, PluginLoader pluginLoader)
+        {
+            var pluginAssembly = pluginLoader.LoadDefaultAssembly();
 
             // This loads MVC application parts from plugin assemblies
             var partFactory = ApplicationPartFactory.GetApplicationPartFactory(pluginAssembly);
@@ -39,7 +60,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var relatedAssembliesAttrs = pluginAssembly.GetCustomAttributes<RelatedAssemblyAttribute>();
             foreach (var attr in relatedAssembliesAttrs)
             {
-                var assembly = plugin.LoadAssembly(attr.AssemblyFileName);
+                var assembly = pluginLoader.LoadAssembly(attr.AssemblyFileName);
                 partFactory = ApplicationPartFactory.GetApplicationPartFactory(assembly);
                 foreach (var part in partFactory.GetApplicationParts(assembly))
                 {

--- a/src/Plugins.Mvc/PublicAPI.Unshipped.txt
+++ b/src/Plugins.Mvc/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Microsoft.Extensions.DependencyInjection.MvcPluginExtensions.AddPluginLoader(this Microsoft.Extensions.DependencyInjection.IMvcBuilder mvcBuilder, McMaster.NETCore.Plugins.PluginLoader pluginLoader) -> Microsoft.Extensions.DependencyInjection.IMvcBuilder

--- a/src/Plugins.Mvc/releasenotes.props
+++ b/src/Plugins.Mvc/releasenotes.props
@@ -1,0 +1,8 @@
+﻿<Project>
+  <PropertyGroup>
+    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '1.0.0'">
+Changes:
+* Add new API: IMvcBuilder.AddPluginLoader(PluginLoader pluginLoader)
+    </PackageReleaseNotes>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
New API for when you want to use MVC, but need to control the creation and lifecycle of PluginLoader manually.

This should open the door to implement features like https://github.com/natemcmaster/DotNetCorePlugins/issues/82