### PR TITLE
Update stale.yml to leave issues open at least 1 year

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # See https://github.com/probot/stale
 
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 365
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 14
 # Label to use when marking an issue as stale
@@ -12,6 +12,7 @@ exemptMilestones: true
 exemptAssignees: true
 exemptLabels:
 - announcement
+- planning
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
Extend the life of issues to 1 year. Open source projects moves slower than business projects. I'm okay keeping issues open for longer to gather support and comments.