### PR TITLE
Ensure assemblies are preloaded into memory when HotReload = true

### DIFF
--- a/samples/hot-reload/run.ps1
+++ b/samples/hot-reload/run.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Stop'
+
+Push-Location $PSScriptRoot
+try {
+    $publish_dir = "$PSScriptRoot/bin/plugins/TimestampedPlugin/"
+
+    function log {
+        Write-Host -NoNewline -ForegroundColor Yellow "run.ps1: "
+        Write-Host $args
+    }
+
+    function publish {
+        Write-Host ""
+        dotnet publish --no-restore TimestampedPlugin/ -o $publish_dir -nologo
+        Write-Host ""
+    }
+
+    log "Compiling apps"
+
+    & dotnet build HotReloadApp -nologo -clp:NoSummary
+    & publish
+
+    log "Use CTRL+C to exit"
+
+    $bg_args = @("run", "--no-build", "--project", "HotReloadApp", "$publish_dir/TimestampedPlugin.dll")
+    $host_process = Start-Process -NoNewWindow -FilePath dotnet -ArgumentList $bg_args
+    try {
+        while ($true) {
+            Start-Sleep 5
+            log "Rebuilding plugin..."
+            publish
+        }
+    }
+    finally {
+        $host_process.Kill()
+    }
+}
+finally {
+    Pop-Location
+}

--- a/src/Plugins/Loader/ManagedLoadContext.cs
+++ b/src/Plugins/Loader/ManagedLoadContext.cs
@@ -105,7 +105,7 @@ namespace McMaster.NETCore.Plugins.Loader
             var resolvedPath = _dependencyResolver.ResolveAssemblyToPath(assemblyName);
             if (!string.IsNullOrEmpty(resolvedPath) && File.Exists(resolvedPath))
             {
-                return LoadFromAssemblyPath(resolvedPath);
+                return LoadAssemblyFromFilePath(resolvedPath);
             }
 #endif
 
@@ -120,7 +120,7 @@ namespace McMaster.NETCore.Plugins.Loader
                     var resourcePath = Path.Combine(resourceRoot, assemblyName.CultureName, assemblyName.Name + ".dll");
                     if (File.Exists(resourcePath))
                     {
-                        return LoadFromAssemblyPath(resourcePath);
+                        return LoadAssemblyFromFilePath(resourcePath);
                     }
                 }
 
@@ -131,7 +131,7 @@ namespace McMaster.NETCore.Plugins.Loader
             {
                 if (SearchForLibrary(library, out var path) && path != null)
                 {
-                    return LoadFromAssemblyPath(path);
+                    return LoadAssemblyFromFilePath(path);
                 }
             }
             else
@@ -141,18 +141,18 @@ namespace McMaster.NETCore.Plugins.Loader
                 var localFile = Path.Combine(_basePath, assemblyName.Name + ".dll");
                 if (File.Exists(localFile))
                 {
-                    return LoadFromAssemblyPath(localFile);
+                    return LoadAssemblyFromFilePath(localFile);
                 }
             }
 
             return null;
         }
 
-        private new Assembly LoadFromAssemblyPath(string path)
+        public Assembly LoadAssemblyFromFilePath(string path)
         {
             if (!_loadInMemory)
             {
-                return base.LoadFromAssemblyPath(path);
+                return LoadFromAssemblyPath(path);
             }
 
             using var file = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);

--- a/src/Plugins/PluginLoader.cs
+++ b/src/Plugins/PluginLoader.cs
@@ -188,7 +188,7 @@ namespace McMaster.NETCore.Plugins
         }
 
         private readonly PluginConfig _config;
-        private AssemblyLoadContext _context;
+        private ManagedLoadContext _context;
         private readonly AssemblyLoadContextBuilder _contextBuilder;
         private volatile bool _disposed;
 
@@ -204,7 +204,7 @@ namespace McMaster.NETCore.Plugins
         {
             _config = config ?? throw new ArgumentNullException(nameof(config));
             _contextBuilder = CreateLoadContextBuilder(config);
-            _context = _contextBuilder.Build();
+            _context = (ManagedLoadContext)_contextBuilder.Build();
 #if FEATURE_UNLOAD
             if (config.EnableHotReload)
             {
@@ -251,7 +251,7 @@ namespace McMaster.NETCore.Plugins
             }
 
             _context.Unload();
-            _context = _contextBuilder.Build();
+            _context = (ManagedLoadContext)_contextBuilder.Build();
             GC.Collect();
             GC.WaitForPendingFinalizers();
             Reloaded?.Invoke(this, new PluginReloadedEventArgs(this));
@@ -296,7 +296,7 @@ namespace McMaster.NETCore.Plugins
         public Assembly LoadDefaultAssembly()
         {
             EnsureNotDisposed();
-            return _context.LoadFromAssemblyPath(_config.MainAssemblyPath);
+            return _context.LoadAssemblyFromFilePath(_config.MainAssemblyPath);
         }
 
         /// <summary>
@@ -316,7 +316,7 @@ namespace McMaster.NETCore.Plugins
         /// <param name="assemblyPath">The assembly path.</param>
         /// <returns>The assembly.</returns>
         public Assembly LoadAssemblyFromPath(string assemblyPath)
-            => _context.LoadFromAssemblyPath(assemblyPath);
+            => _context.LoadAssemblyFromFilePath(assemblyPath);
 
         /// <summary>
         /// Load an assembly by name.


### PR DESCRIPTION
Fixes #93 

The original implementation of hot-reload has issues on Windows due to the way Windows locks assemblies. This change ensures assemblies are always pre-loaded into memory so there are no locks on plugin assemblies.