### PR TITLE
Support Usage of Library in Non-Default AssemblyLoadContext(s)

### DIFF
--- a/DotNetCorePlugins.sln
+++ b/DotNetCorePlugins.sln
@@ -99,21 +99,31 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyPlugin2", "samples\depend
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DI.SharedAbstractions", "samples\dependency-injection\DI.SharedAbstractions\DI.SharedAbstractions.csproj", "{40E1EB3E-0CAE-45B1-B146-C7C8B3865C65}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransitiveDep.v2", "test\TestProjects\TransitiveDep.v2\TransitiveDep.v2.csproj", "{CE0C0288-E0A3-4B06-B05F-CCBFFC4E7BF6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransitiveDep.v2", "test\TestProjects\TransitiveDep.v2\TransitiveDep.v2.csproj", "{CE0C0288-E0A3-4B06-B05F-CCBFFC4E7BF6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedAbstraction.v1", "test\TestProjects\SharedAbstraction.v1\SharedAbstraction.v1.csproj", "{D5519A45-AD22-41DB-ADDA-589C3E7D6C0D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedAbstraction.v1", "test\TestProjects\SharedAbstraction.v1\SharedAbstraction.v1.csproj", "{D5519A45-AD22-41DB-ADDA-589C3E7D6C0D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransitiveDep.v1", "test\TestProjects\TransitiveDep.v1\TransitiveDep.v1.csproj", "{704EA4BF-71D9-442B-96D9-9B3E81068CC2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransitiveDep.v1", "test\TestProjects\TransitiveDep.v1\TransitiveDep.v1.csproj", "{704EA4BF-71D9-442B-96D9-9B3E81068CC2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedAbstraction.v2", "test\TestProjects\SharedAbstraction.v2\SharedAbstraction.v2.csproj", "{3549E707-E4B0-428F-9CF4-5B5B86219B6D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedAbstraction.v2", "test\TestProjects\SharedAbstraction.v2\SharedAbstraction.v2.csproj", "{3549E707-E4B0-428F-9CF4-5B5B86219B6D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransitivePlugin", "test\TestProjects\TransitivePlugin\TransitivePlugin.csproj", "{1EA2BACF-3D44-4B05-A0E7-727AE13E693D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransitivePlugin", "test\TestProjects\TransitivePlugin\TransitivePlugin.csproj", "{1EA2BACF-3D44-4B05-A0E7-727AE13E693D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "hot-reload", "hot-reload", "{07E0093F-F05C-4AED-A489-1254C9854E21}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotReloadApp", "samples\hot-reload\HotReloadApp\HotReloadApp.csproj", "{D815817F-CC0D-42CC-9C9C-8E229B9C03A8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotReloadApp", "samples\hot-reload\HotReloadApp\HotReloadApp.csproj", "{D815817F-CC0D-42CC-9C9C-8E229B9C03A8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimestampedPlugin", "samples\hot-reload\TimestampedPlugin\TimestampedPlugin.csproj", "{FAB78955-5E1F-4E6D-A79B-F85D8D18BDF4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TimestampedPlugin", "samples\hot-reload\TimestampedPlugin\TimestampedPlugin.csproj", "{FAB78955-5E1F-4E6D-A79B-F85D8D18BDF4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WithOwnPlugins", "test\TestProjects\WithOwnPlugins\WithOwnPlugins.csproj", "{F47ED576-F347-44C4-BEC7-6C00A500555A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WithOwnPluginsContract", "test\TestProjects\WithOwnPluginsContract\WithOwnPluginsContract.csproj", "{F55E52BD-A846-4808-9482-E4AB0921328D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WithOurPluginsPluginContract", "test\TestProjects\WithOurPluginsPluginContract\WithOurPluginsPluginContract.csproj", "{7C7B19F2-5822-4DA2-80D2-E077CE705039}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WithOurPluginsPluginA", "test\TestProjects\WithOurPluginsPluginA\WithOurPluginsPluginA.csproj", "{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WithOurPluginsPluginB", "test\TestProjects\WithOurPluginsPluginB\WithOurPluginsPluginB.csproj", "{D5B3DA06-E60D-4C85-8835-6A26003365AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -569,6 +579,66 @@ Global
 		{FAB78955-5E1F-4E6D-A79B-F85D8D18BDF4}.Release|x64.Build.0 = Release|Any CPU
 		{FAB78955-5E1F-4E6D-A79B-F85D8D18BDF4}.Release|x86.ActiveCfg = Release|Any CPU
 		{FAB78955-5E1F-4E6D-A79B-F85D8D18BDF4}.Release|x86.Build.0 = Release|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Debug|x64.Build.0 = Debug|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Debug|x86.Build.0 = Debug|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Release|x64.ActiveCfg = Release|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Release|x64.Build.0 = Release|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Release|x86.ActiveCfg = Release|Any CPU
+		{F47ED576-F347-44C4-BEC7-6C00A500555A}.Release|x86.Build.0 = Release|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Debug|x64.Build.0 = Debug|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Debug|x86.Build.0 = Debug|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Release|x64.ActiveCfg = Release|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Release|x64.Build.0 = Release|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Release|x86.ActiveCfg = Release|Any CPU
+		{F55E52BD-A846-4808-9482-E4AB0921328D}.Release|x86.Build.0 = Release|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Debug|x64.Build.0 = Debug|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Debug|x86.Build.0 = Debug|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Release|x64.ActiveCfg = Release|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Release|x64.Build.0 = Release|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Release|x86.ActiveCfg = Release|Any CPU
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039}.Release|x86.Build.0 = Release|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Debug|x64.Build.0 = Debug|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Debug|x86.Build.0 = Debug|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Release|x64.ActiveCfg = Release|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Release|x64.Build.0 = Release|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845}.Release|x86.Build.0 = Release|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Debug|x64.Build.0 = Debug|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Release|x64.ActiveCfg = Release|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Release|x64.Build.0 = Release|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -617,6 +687,11 @@ Global
 		{07E0093F-F05C-4AED-A489-1254C9854E21} = {F49FFE3B-E1AE-483E-951F-D498F6ABA08E}
 		{D815817F-CC0D-42CC-9C9C-8E229B9C03A8} = {07E0093F-F05C-4AED-A489-1254C9854E21}
 		{FAB78955-5E1F-4E6D-A79B-F85D8D18BDF4} = {07E0093F-F05C-4AED-A489-1254C9854E21}
+		{F47ED576-F347-44C4-BEC7-6C00A500555A} = {98E964A2-55DA-4740-9F2E-B64FDF6715DB}
+		{F55E52BD-A846-4808-9482-E4AB0921328D} = {98E964A2-55DA-4740-9F2E-B64FDF6715DB}
+		{7C7B19F2-5822-4DA2-80D2-E077CE705039} = {98E964A2-55DA-4740-9F2E-B64FDF6715DB}
+		{3A7712FC-9A91-4322-AF7E-4FEC6EB0D845} = {98E964A2-55DA-4740-9F2E-B64FDF6715DB}
+		{D5B3DA06-E60D-4C85-8835-6A26003365AA} = {98E964A2-55DA-4740-9F2E-B64FDF6715DB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B1AF41DC-A03E-47B1-BBDB-3DC27ABD9F74}

--- a/README.md
+++ b/README.md
@@ -221,3 +221,16 @@ using (loader.EnterContextualReflection())
 ```
 
 Read [this post written by .NET Core engineers](https://github.com/dotnet/coreclr/blob/v3.0.0/Documentation/design-docs/AssemblyLoadContext.ContextualReflection.md) for even more details on contextual reflection.
+
+## Non-Default AssemblyLoadContext(s)
+
+By default, DotNetCorePlugins assumes that you are working from the *Default* `ApplicationLoadContext`. However, sometimes, in certain advanced scenarios and situations, this may not be the case.
+
+For example: You may be creating plugins from inside a plugin or running .NET inside a runtime host created natively from native code (which automatically creates a load context).
+
+`CreateFromAssemblyFile`, as well as other under the hood APIs support this kind of workflow:
+
+```csharp
+// Overriding default ALC to use: `config => config.DefaultContext = _loadContext`
+PluginLoader.CreateFromAssemblyFile(dllPath, isUnloadable, sharedTypes, config => config.DefaultContext = _loadContext);
+```

--- a/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
+++ b/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
@@ -23,7 +23,7 @@ namespace McMaster.NETCore.Plugins.Loader
         private readonly Dictionary<string, NativeLibrary> _nativeLibraries = new Dictionary<string, NativeLibrary>(StringComparer.Ordinal);
         private readonly HashSet<string> _privateAssemblies = new HashSet<string>(StringComparer.Ordinal);
         private readonly HashSet<string> _defaultAssemblies = new HashSet<string>(StringComparer.Ordinal);
-        private AssemblyLoadContext _defaultLoadContext = AssemblyLoadContext.Default;
+        private AssemblyLoadContext _defaultLoadContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()) ?? AssemblyLoadContext.Default;
         private string? _mainAssemblyPath;
         private bool _preferDefaultLoadContext;
 

--- a/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
+++ b/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
@@ -23,6 +23,7 @@ namespace McMaster.NETCore.Plugins.Loader
         private readonly Dictionary<string, NativeLibrary> _nativeLibraries = new Dictionary<string, NativeLibrary>(StringComparer.Ordinal);
         private readonly HashSet<string> _privateAssemblies = new HashSet<string>(StringComparer.Ordinal);
         private readonly HashSet<string> _defaultAssemblies = new HashSet<string>(StringComparer.Ordinal);
+        private AssemblyLoadContext _defaultLoadContext = AssemblyLoadContext.Default;
         private string? _mainAssemblyPath;
         private bool _preferDefaultLoadContext;
 
@@ -59,6 +60,7 @@ namespace McMaster.NETCore.Plugins.Loader
                 _defaultAssemblies,
                 _additionalProbingPaths,
                 resourceProbingPaths,
+                _defaultLoadContext,
                 _preferDefaultLoadContext,
 #if FEATURE_UNLOAD
                 _isCollectible,
@@ -88,6 +90,19 @@ namespace McMaster.NETCore.Plugins.Loader
             }
 
             _mainAssemblyPath = path;
+            return this;
+        }
+
+        /// <summary>
+        /// Replaces the default <see cref="AssemblyLoadContext"/> used by the <see cref="AssemblyLoadContextBuilder"/>.
+        /// Use this feature if the <see cref="AssemblyLoadContext"/> of the <see cref="Assembly"/> is not the Runtime's default load context.
+        /// i.e. (AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly) != <see cref="AssemblyLoadContext.Default"/>
+        /// </summary>
+        /// <param name="context">The context to set.</param>
+        /// <returns>The builder.</returns>
+        public AssemblyLoadContextBuilder SetDefaultContext(AssemblyLoadContext context)
+        {
+            _defaultLoadContext = context ?? throw new ArgumentException($"Bad Argument: AssemblyLoadContext in {nameof(AssemblyLoadContextBuilder)}.{nameof(SetDefaultContext)} is null.");
             return this;
         }
 
@@ -141,7 +156,7 @@ namespace McMaster.NETCore.Plugins.Loader
             // Recursively load and find all dependencies of default assemblies.
             // This sacrifices some performance for determinism in how transitive
             // dependencies will be shared between host and plugin.
-            var assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(assemblyName);
+            var assembly = _defaultLoadContext.LoadFromAssemblyName(assemblyName);
             foreach (var reference in assembly.GetReferencedAssemblies())
             {
                 PreferDefaultLoadContextAssembly(reference);

--- a/src/Plugins/PluginConfig.cs
+++ b/src/Plugins/PluginConfig.cs
@@ -67,7 +67,7 @@ namespace McMaster.NETCore.Plugins
         /// Use this feature if the <see cref="AssemblyLoadContext"/> of the <see cref="Assembly"/> is not the Runtime's default load context.
         /// i.e. (AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly) != <see cref="AssemblyLoadContext.Default"/>
         /// </summary>
-        public AssemblyLoadContext DefaultContext { get; set; } = AssemblyLoadContext.Default;
+        public AssemblyLoadContext DefaultContext { get; set; } = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()) ?? AssemblyLoadContext.Default;
 
 #if FEATURE_UNLOAD
         private bool _isUnloadable;

--- a/src/Plugins/PluginConfig.cs
+++ b/src/Plugins/PluginConfig.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Loader;
 
 namespace McMaster.NETCore.Plugins
 {
@@ -60,6 +61,13 @@ namespace McMaster.NETCore.Plugins
         /// </seealso>
         /// </summary>
         public bool PreferSharedTypes { get; set; }
+
+        /// <summary>
+        /// If set, replaces the default <see cref="AssemblyLoadContext"/> used by the <see cref="PluginLoader"/>.
+        /// Use this feature if the <see cref="AssemblyLoadContext"/> of the <see cref="Assembly"/> is not the Runtime's default load context.
+        /// i.e. (AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly) != <see cref="AssemblyLoadContext.Default"/>
+        /// </summary>
+        public AssemblyLoadContext DefaultContext { get; set; } = AssemblyLoadContext.Default;
 
 #if FEATURE_UNLOAD
         private bool _isUnloadable;

--- a/src/Plugins/PluginLoader.cs
+++ b/src/Plugins/PluginLoader.cs
@@ -342,6 +342,7 @@ namespace McMaster.NETCore.Plugins
             var builder = new AssemblyLoadContextBuilder();
 
             builder.SetMainAssemblyPath(config.MainAssemblyPath);
+            builder.SetDefaultContext(config.DefaultContext);
 
             foreach (var ext in config.PrivateAssemblies)
             {

--- a/src/Plugins/PublicAPI.Shipped.txt
+++ b/src/Plugins/PublicAPI.Shipped.txt
@@ -14,16 +14,19 @@ McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.AddResourceProbingPat
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.AssemblyLoadContextBuilder() -> void
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.Build() -> System.Runtime.Loader.AssemblyLoadContext
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.PreferDefaultLoadContext(bool preferDefaultLoadContext) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
-McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.PreferDefaultLoadContextAssembly(System.Reflection.AssemblyName assemblyName) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
-McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.PreferLoadContextAssembly(System.Reflection.AssemblyName assemblyName) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
 McMaster.NETCore.Plugins.Loader.DependencyContextExtensions
 McMaster.NETCore.Plugins.Loader.RuntimeConfigExtensions
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.EnableUnloading() -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.PreloadAssembliesIntoMemory() -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.SetMainAssemblyPath(string path) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
+McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.PreferDefaultLoadContextAssembly(System.Reflection.AssemblyName assemblyName) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
+McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.PreferLoadContextAssembly(System.Reflection.AssemblyName assemblyName) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
+McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.SetDefaultContext(System.Runtime.Loader.AssemblyLoadContext context) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
 McMaster.NETCore.Plugins.PluginConfig
 McMaster.NETCore.Plugins.PluginConfig.EnableHotReload.get -> bool
 McMaster.NETCore.Plugins.PluginConfig.EnableHotReload.set -> void
+McMaster.NETCore.Plugins.PluginConfig.DefaultContext.get -> System.Runtime.Loader.AssemblyLoadContext
+McMaster.NETCore.Plugins.PluginConfig.DefaultContext.set -> void
 McMaster.NETCore.Plugins.PluginLoader.Reload() -> void
 McMaster.NETCore.Plugins.PluginLoader.Reloaded -> McMaster.NETCore.Plugins.PluginReloadedEventHandler
 McMaster.NETCore.Plugins.PluginReloadedEventArgs

--- a/test/Plugins.Tests/McMaster.NETCore.Plugins.Tests.csproj
+++ b/test/Plugins.Tests/McMaster.NETCore.Plugins.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Plugins\McMaster.NETCore.Plugins.csproj" />
+    <ProjectReference Include="..\TestProjects\WithOwnPluginsContract\WithOwnPluginsContract.csproj" />
     <ProjectReference Include="..\TestProjects\ReferencedLibv1\ReferencedLibv1.csproj" />
     <ProjectReference Include="..\TestProjects\SharedAbstraction.v2\SharedAbstraction.v2.csproj" />
     <TestProject Include="..\TestProjects\ReferencedLibv2\ReferencedLibv2.csproj" />
@@ -29,6 +30,7 @@
     <TestProject Include="..\TestProjects\SqlClientApp\SqlClientApp.csproj" />
     <TestProject Include="..\TestProjects\TransitivePlugin\TransitivePlugin.csproj" />
     <PublishedTestProject Include="..\TestProjects\PowerShellPlugin\PowerShellPlugin.csproj" />
+    <MultitargetTestProject Include="..\TestProjects\WithOwnPlugins\WithOwnPlugins.csproj" />
   </ItemGroup>
 
   <Import Project="TestProjectRefs.targets" />

--- a/test/Plugins.Tests/SharedTypesTests.cs
+++ b/test/Plugins.Tests/SharedTypesTests.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
 using Test.Referenced.Library;
 using Test.Shared.Abstraction;
+using WithOwnPluginsContract;
 using Xunit;
 
 namespace McMaster.NETCore.Plugins.Tests
@@ -50,6 +52,55 @@ namespace McMaster.NETCore.Plugins.Tests
             var config = Activator.CreateInstance(configType);
             var transitiveInstance = configType.GetMethod("GetTransitiveType")?.Invoke(config, null);
             Assert.IsType<Test.Transitive.TransitiveSharedType>(transitiveInstance);
+        }
+
+        /// <summary>
+        /// This is a carefully crafted example which tests
+        /// whether the library can be used outside of the default load context
+        /// (<see cref="AssemblyLoadContext.Default"/>).
+        /// 
+        /// It works by loading a plugin (that gets loaded into another ALC)
+        /// which in turn loads its own plugins using the library. If said plugin
+        /// can successfully share its own types, the test should work.
+        /// </summary>
+        [Fact]
+        public void NonDefaultLoadContextsAreSupported()
+        {
+            /* The loaded plugin here will be in its own ALC.
+             * It will load its own plugins, which are not known to this ALC.
+             * Then this ALC will ask that ALC if it managed to successfully its own plugins.
+             */
+            
+            using var loader = PluginLoader.CreateFromAssemblyFile(TestResources.GetTestProjectAssembly("WithOwnPlugins"), new[] { typeof(IWithOwnPlugins) });
+            var assembly = loader.LoadDefaultAssembly();
+            var configType = assembly.GetType("WithOwnPlugins.WithOwnPlugins", throwOnError: true)!;
+            var config = (IWithOwnPlugins?)Activator.CreateInstance(configType);
+
+            /*
+             * Here, we have made sure that neither WithOwnPlugins or its own plugins have any way to be
+             * accidentally unified with the default (current for our tests) ALC. We did this by ensuring they are
+             * not loaded in the default ALC in the first place, hence the use of the `IWithOwnPlugins` interface.
+             *
+             * We are simulating a real use case scenario where the plugin host is 100% unaware of the
+             * plugin's own plugins.
+             *
+             * An important additional note:
+             * - Although the assembly of WithOurPlugins is not directly referenced thanks to the
+             *   ReferenceOutputAssembly = false property, its contents will still be copied to the output.
+             * - This is problematic because the test runner seems to load all of the Assemblies present in the same
+             *   directory as the test assembly, regardless of whether referenced or not.
+             * - Therefore we store the plugins of `WithOwnPlugins` are output in a `Plugins` directory.
+             *   (see csproj of WithOwnPlugins, Link property)
+             *
+             * You can ensure that WithOwnPlugins or its plugins are not loaded by inspecting the following:
+             * AssemblyLoadContext.Default.Assemblies
+             *
+             * Even if it was loaded, there's an extra check on the other side to ensure no unification could happen.
+             * Nothing wrong with being extra careful ;).
+             */
+
+            var callingContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly());
+            Assert.True(config?.TryLoadPluginsInCustomContext(callingContext));
         }
     }
 }

--- a/test/Plugins.Tests/TestProjectRefs.targets
+++ b/test/Plugins.Tests/TestProjectRefs.targets
@@ -1,6 +1,11 @@
 ﻿<Project>
 
   <ItemDefinitionGroup>
+    <MultitargetTestProject>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <OutputItemType>_ResolvedTestProjectReference</OutputItemType>
+    </MultitargetTestProject>
     <TestProject>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
@@ -16,7 +21,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <ProjectReference Include="@(TestProject);@(PublishedTestProject)" />
+    <ProjectReference Include="@(TestProject);@(MultitargetTestProject);@(PublishedTestProject)" />
   </ItemGroup>
 
   <Target Name="GeneratePathToTestProjects"

--- a/test/TestProjects/WithOurPluginsPluginA/Class1.cs
+++ b/test/TestProjects/WithOurPluginsPluginA/Class1.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using WithOurPluginsPluginContract;
+
+namespace WithOurPluginsPluginA
+{
+    public class Class1 : ISayHello
+    {
+        public string SayHello() => $"Hello from {nameof(WithOurPluginsPluginA)}";
+    }
+}

--- a/test/TestProjects/WithOurPluginsPluginA/WithOurPluginsPluginA.csproj
+++ b/test/TestProjects/WithOurPluginsPluginA/WithOurPluginsPluginA.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WithOurPluginsPluginContract\WithOurPluginsPluginContract.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestProjects/WithOurPluginsPluginB/Class1.cs
+++ b/test/TestProjects/WithOurPluginsPluginB/Class1.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using WithOurPluginsPluginContract;
+
+namespace WithOurPluginsPluginB
+{
+    public class Class1 : ISayHello
+    {
+        public string SayHello() => $"Hello from {nameof(WithOurPluginsPluginB)}";
+    }
+}

--- a/test/TestProjects/WithOurPluginsPluginB/WithOurPluginsPluginB.csproj
+++ b/test/TestProjects/WithOurPluginsPluginB/WithOurPluginsPluginB.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WithOurPluginsPluginContract\WithOurPluginsPluginContract.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestProjects/WithOurPluginsPluginContract/ISayHello.cs
+++ b/test/TestProjects/WithOurPluginsPluginContract/ISayHello.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace WithOurPluginsPluginContract
+{
+    public interface ISayHello
+    {
+        string SayHello();
+    }
+}

--- a/test/TestProjects/WithOurPluginsPluginContract/WithOurPluginsPluginContract.csproj
+++ b/test/TestProjects/WithOurPluginsPluginContract/WithOurPluginsPluginContract.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test/TestProjects/WithOwnPlugins/WithOwnPlugins.cs
+++ b/test/TestProjects/WithOwnPlugins/WithOwnPlugins.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using McMaster.NETCore.Plugins;
+using WithOurPluginsPluginContract;
+using WithOwnPluginsContract;
+
+namespace WithOwnPlugins
+{
+    public class WithOwnPlugins : IWithOwnPlugins
+    {
+        public bool TryLoadPluginsInCustomContext(AssemblyLoadContext? callingContext)
+        {
+            var currentContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly());
+            if (currentContext == callingContext)
+            {
+                throw new ArgumentException("The context of the caller is the context of this assembly. This invalidates the test.");
+            }
+
+            #if NETCOREAPP3_0
+            /*
+                Ensure the source calling context does not have our plugin's interfaces loaded.
+                This guarantees that the Assembly cannot possibly unify with the default load context.
+
+                Note:
+                The code below this check would fail anyway if the assembly would unify with the default context.
+                This is more of a safety check to ensure "correctness" as opposed to anything else.
+             */
+            var sayHelloAssembly = typeof(ISayHello).Assembly;
+            if (callingContext?.Assemblies.Contains(sayHelloAssembly) == true) // .Assemblies API not available in Core 2.X
+            {
+                throw new ArgumentException("The context of the caller has this plugin's interface to interact with its own plugins loaded. Test is void.");
+            }
+            #endif 
+
+            // Load our own plugins: Remember, we are in an isolated, non-default ALC.
+            var plugins = new List<ISayHello?>();
+            string[] assemblyNames = { "Plugins/WithOurPluginsPluginA.dll", "Plugins/WithOurPluginsPluginB.dll" };
+
+            foreach (var assemblyName in assemblyNames)
+            {
+                var currentAssemblyFolderPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? throw new Exception("Unable to get folder path for currently executing assembly.");
+                var pluginPath = Path.Combine(currentAssemblyFolderPath, assemblyName);
+
+                using var loader = PluginLoader.CreateFromAssemblyFile(pluginPath, new[] { typeof(ISayHello) });
+                var assembly = loader.LoadDefaultAssembly();
+                var configType = assembly.GetTypes().First(x => typeof(ISayHello).IsAssignableFrom(x) && !x.IsAbstract);
+                var plugin = (ISayHello?)Activator.CreateInstance(configType);
+                if (plugin == null)
+                {
+                    throw new Exception($"Failed to load instance of {nameof(ISayHello)} from plugin.");
+                }
+
+                plugins.Add(plugin);
+            }
+
+            // Shouldn't need to check for this but just in case to absolutely make sure.
+            if (plugins.Any(plugin => String.IsNullOrEmpty(plugin?.SayHello())))
+            {
+                throw new Exception("No value returned from plugin.");
+            }
+
+            return true;
+        }
+    }
+}

--- a/test/TestProjects/WithOwnPlugins/WithOwnPlugins.csproj
+++ b/test/TestProjects/WithOwnPlugins/WithOwnPlugins.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Plugins\McMaster.NETCore.Plugins.csproj" />
+    <ProjectReference Include="..\WithOurPluginsPluginA\WithOurPluginsPluginA.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" OutputItemType="Content" CopyToOutputDirectory="Always" Link="Plugins/%(RecursiveDir)%(Filename).dll" />
+    <ProjectReference Include="..\WithOurPluginsPluginB\WithOurPluginsPluginB.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" OutputItemType="Content" CopyToOutputDirectory="Always" Link="Plugins/%(RecursiveDir)%(Filename).dll" />
+    <ProjectReference Include="..\WithOurPluginsPluginContract\WithOurPluginsPluginContract.csproj" />
+    <ProjectReference Include="..\WithOwnPluginsContract\WithOwnPluginsContract.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestProjects/WithOwnPluginsContract/IWithOwnPlugins.cs
+++ b/test/TestProjects/WithOwnPluginsContract/IWithOwnPlugins.cs
@@ -1,0 +1,9 @@
+﻿using System.Runtime.Loader;
+
+namespace WithOwnPluginsContract
+{
+    public interface IWithOwnPlugins
+    {
+        bool TryLoadPluginsInCustomContext(AssemblyLoadContext? callingContext);
+    }
+}

--- a/test/TestProjects/WithOwnPluginsContract/WithOwnPluginsContract.csproj
+++ b/test/TestProjects/WithOwnPluginsContract/WithOwnPluginsContract.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
For users of this library in more advanced scenarios, this pull request adds the ability to use the library outside of the Default `AssemblyLoadContext`. The Readme was also updated to make note of this use case.

More details behind the motives of this PR can be found here: https://github.com/natemcmaster/DotNetCorePlugins/issues/110

## Tests
Manually checked against all existing runtimes and configurations and an actual real program that requires this change.

I didn't necessarily add any additional tests, since as far as I'm concerned, no actual real logic was changed. At the core, all this PR does is replace two references to `AssemblyLoadContext.Default` with a user defined ALC, which defaults to Default. A method was added to ALC Builder and constructor of ManagedLoadContext (internal, no breaking public API changes) changed.

Only real thing of note is `ManagedLoadContext.Load()` now doesn't return null on success, and instead the assembly directly, since we're not asking the framework anymore to default to the default ALC. This is a non-breaking change.