### PR TITLE
Shadow copy unmanaged DLLs when reloading enabled

### DIFF
--- a/samples/hot-reload/TimestampedPlugin/InfoDisplayer.cs
+++ b/samples/hot-reload/TimestampedPlugin/InfoDisplayer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Data.Sqlite;
 
 namespace TimestampedPlugin
 {
@@ -8,6 +9,12 @@ namespace TimestampedPlugin
     {
         public static void Print()
         {
+            // Use something from Microsoft.Data.Sqlite to trigger loading of native dependency
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = "HELLO"
+            };
+
             var compileTimestamp = typeof(InfoDisplayer)
                 .Assembly
                 .GetCustomAttributes<AssemblyMetadataAttribute>()
@@ -16,7 +23,7 @@ namespace TimestampedPlugin
             Console.ForegroundColor = ConsoleColor.Green;
             Console.Write("TimestampedPlugin: ");
             Console.ResetColor();
-            Console.WriteLine($"this plugin was compiled at {compileTimestamp}");
+            Console.WriteLine($"this plugin was compiled at {compileTimestamp}. {connectionString.DataSource}!");
         }
     }
 }

--- a/samples/hot-reload/TimestampedPlugin/TimestampedPlugin.csproj
+++ b/samples/hot-reload/TimestampedPlugin/TimestampedPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,6 +9,10 @@
       <_Parameter1>CompileTimestamp</_Parameter1>
       <_Parameter2>$([System.DateTime]::Now.ToString('h:mm:ss tt'))</_Parameter2>
     </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
+++ b/src/Plugins/Loader/AssemblyLoadContextBuilder.cs
@@ -30,6 +30,7 @@ namespace McMaster.NETCore.Plugins.Loader
 #if FEATURE_UNLOAD
         private bool _isCollectible;
         private bool _loadInMemory;
+        private bool _shadowCopyNativeLibraries;
 #endif
 
         /// <summary>
@@ -64,10 +65,12 @@ namespace McMaster.NETCore.Plugins.Loader
                 _preferDefaultLoadContext,
 #if FEATURE_UNLOAD
                 _isCollectible,
-                _loadInMemory);
+                _loadInMemory,
+                _shadowCopyNativeLibraries);
 #else
                 isCollectible: false,
-                loadInMemory: false);
+                loadInMemory: false,
+                shadowCopyNativeLibraries: false);
 #endif
         }
 
@@ -277,6 +280,18 @@ namespace McMaster.NETCore.Plugins.Loader
         public AssemblyLoadContextBuilder PreloadAssembliesIntoMemory()
         {
             _loadInMemory = true; // required to prevent dotnet from locking loaded files
+            return this;
+        }
+
+        /// <summary>
+        /// Shadow copy native libraries (unmanaged DLLs) to avoid locking of these files.
+        /// This is not as efficient, so is not enabled by default, but is required for scenarios
+        /// like hot reloading of plugins dependent on native libraries.
+        /// </summary>
+        /// <returns>The builder</returns>
+        public AssemblyLoadContextBuilder ShadowCopyNativeLibraries()
+        {
+            _shadowCopyNativeLibraries = true;
             return this;
         }
 #endif

--- a/src/Plugins/Loader/ManagedLoadContext.cs
+++ b/src/Plugins/Loader/ManagedLoadContext.cs
@@ -186,9 +186,7 @@ namespace McMaster.NETCore.Plugins.Loader
             var resolvedPath = _dependencyResolver.ResolveUnmanagedDllToPath(unmanagedDllName);
             if (!string.IsNullOrEmpty(resolvedPath) && File.Exists(resolvedPath))
             {
-                return _shadowCopyNativeLibraries
-                    ? LoadUnmanagedDllFromShadowCopy(resolvedPath)
-                    : LoadUnmanagedDllFromPath(resolvedPath);
+                return LoadUnmanagedDllFromResolvedPath(resolvedPath, normalizePath: false);
             }
 #endif
 
@@ -319,13 +317,16 @@ namespace McMaster.NETCore.Plugins.Loader
             return false;
         }
 
-        private IntPtr LoadUnmanagedDllFromResolvedPath(string unmanagedDllPath)
+        private IntPtr LoadUnmanagedDllFromResolvedPath(string unmanagedDllPath, bool normalizePath = true)
         {
-            var normalized = Path.GetFullPath(unmanagedDllPath);
+            if (normalizePath)
+            {
+                unmanagedDllPath = Path.GetFullPath(unmanagedDllPath);
+            }
 
             return _shadowCopyNativeLibraries
-                ? LoadUnmanagedDllFromShadowCopy(normalized)
-                : LoadUnmanagedDllFromPath(normalized);
+                ? LoadUnmanagedDllFromShadowCopy(unmanagedDllPath)
+                : LoadUnmanagedDllFromPath(unmanagedDllPath);
         }
 
         private IntPtr LoadUnmanagedDllFromShadowCopy(string unmanagedDllPath)

--- a/src/Plugins/PluginLoader.cs
+++ b/src/Plugins/PluginLoader.cs
@@ -363,6 +363,7 @@ namespace McMaster.NETCore.Plugins
             if (config.EnableHotReload)
             {
                 builder.PreloadAssembliesIntoMemory();
+                builder.ShadowCopyNativeLibraries();
             }
 #endif
 

--- a/src/Plugins/PublicAPI.Unshipped.txt
+++ b/src/Plugins/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.ShadowCopyNativeLibraries() -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder


### PR DESCRIPTION
When hot reloading is enabled, unmanaged DLLs will be shadow copied to a
unique temp directory per PluginLoader to allow hot reloading of these
DLLs. The temp directory is deleted when the AssemblyLoadContext is
unloaded.

Fixes: #118