### PR TITLE
Add API to preload specific unmanaged DLLs

### DIFF
--- a/samples/hot-reload/HotReloadApp/Program.cs
+++ b/samples/hot-reload/HotReloadApp/Program.cs
@@ -11,7 +11,11 @@ namespace HostApp
         {
             var pluginPath = args[0];
             var loader = PluginLoader.CreateFromAssemblyFile(pluginPath,
-                config => config.EnableHotReload = true);
+                config =>
+                {
+                    config.EnableHotReload = true;
+                    config.NativeLibrariesToPreload.Add("e_sqlite3");
+                });
 
             loader.Reloaded += ShowPluginInfo;
 

--- a/samples/hot-reload/TimestampedPlugin/InfoDisplayer.cs
+++ b/samples/hot-reload/TimestampedPlugin/InfoDisplayer.cs
@@ -15,6 +15,8 @@ namespace TimestampedPlugin
                 DataSource = "HELLO"
             };
 
+            using var dbConnection = new SqliteConnection(connectionString.ToString());
+
             var compileTimestamp = typeof(InfoDisplayer)
                 .Assembly
                 .GetCustomAttributes<AssemblyMetadataAttribute>()
@@ -23,7 +25,7 @@ namespace TimestampedPlugin
             Console.ForegroundColor = ConsoleColor.Green;
             Console.Write("TimestampedPlugin: ");
             Console.ResetColor();
-            Console.WriteLine($"this plugin was compiled at {compileTimestamp}. {connectionString.DataSource}!");
+            Console.WriteLine($"this plugin was compiled at {compileTimestamp}.");
         }
     }
 }

--- a/src/Plugins/Loader/ManagedLoadContext.cs
+++ b/src/Plugins/Loader/ManagedLoadContext.cs
@@ -91,6 +91,7 @@ namespace McMaster.NETCore.Plugins.Loader
                 .AsReadOnly();
         }
 
+#if FEATURE_UNLOAD
         // Clean up unmanaged resources
         ~ManagedLoadContext()
         {
@@ -99,6 +100,7 @@ namespace McMaster.NETCore.Plugins.Loader
                 System.Runtime.InteropServices.NativeLibrary.Free(nativeLibraryHandle);
             }
         }
+#endif
 
         /// <summary>
         /// Load an assembly.

--- a/src/Plugins/PluginConfig.cs
+++ b/src/Plugins/PluginConfig.cs
@@ -109,6 +109,19 @@ namespace McMaster.NETCore.Plugins
         /// Default value is 200 milliseconds.
         /// </summary>
         public TimeSpan ReloadDelay { get; set; } = TimeSpan.FromMilliseconds(200);
+
+        /// <summary>
+        /// A list of native library names that is loaded into the assembly load context before
+        /// any other resolving happens. This is might be required when hot reloading is
+        /// enabled and a plugin depends on a native library that is loaded using
+        /// <see cref="System.Runtime.InteropServices.NativeLibrary.Load(string, Assembly, System.Runtime.InteropServices.DllImportSearchPath?)"/>.
+        /// <para>
+        /// If you get exceptions with the message "Unable to load DLL '[X]' or one of its
+        /// dependencies: The specified module could not be found.", add those libraries to this
+        /// list.
+        /// </para>
+        /// </summary>
+        public ICollection<string> NativeLibrariesToPreload { get; protected set; } = new List<string>();
 #endif
     }
 }

--- a/src/Plugins/PluginLoader.cs
+++ b/src/Plugins/PluginLoader.cs
@@ -369,6 +369,11 @@ namespace McMaster.NETCore.Plugins
             {
                 builder.PreloadAssembliesIntoMemory();
                 builder.ShadowCopyNativeLibraries();
+
+                foreach (var nativeLibraryName in config.NativeLibrariesToPreload)
+                {
+                    builder.PreloadNativeLibrary(nativeLibraryName);
+                }
             }
 #endif
 

--- a/src/Plugins/PublicAPI.Unshipped.txt
+++ b/src/Plugins/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+McMaster.NETCore.Plugins.PluginConfig.NativeLibrariesToPreload.get -> System.Collections.Generic.ICollection<string>
+McMaster.NETCore.Plugins.PluginConfig.NativeLibrariesToPreload.set -> void
+McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.PreloadNativeLibrary(string nativeLibraryName) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder


### PR DESCRIPTION
Unmanaged DLLs that are loaded outide the assembly load context are not
found when hot reloading (load in memory) is enabled. This happens when
NativeLibrary.Load(String, Assembly, DllImportSearchPath?) is used.

This change adds an API that lets consumers of this package configure a
set of unmanaged libraries to preload before any other resolving
happens.

Fixes #148