### PR TITLE
Feature: Optional Lazy Loading of Transitive Dependencies

### DIFF
--- a/src/Plugins/PluginConfig.cs
+++ b/src/Plugins/PluginConfig.cs
@@ -63,6 +63,13 @@ namespace McMaster.NETCore.Plugins
         public bool PreferSharedTypes { get; set; }
 
         /// <summary>
+        /// If enabled, will lazy load dependencies of all shared assemblies.
+        /// Reduces plugin load time at the expense of non-determinism in how transitive dependencies are loaded
+        /// between the plugin and the host.
+        /// </summary>
+        public bool IsLazyLoaded { get; set; } = false;
+
+        /// <summary>
         /// If set, replaces the default <see cref="AssemblyLoadContext"/> used by the <see cref="PluginLoader"/>.
         /// Use this feature if the <see cref="AssemblyLoadContext"/> of the <see cref="Assembly"/> is not the Runtime's default load context.
         /// i.e. (AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly) != <see cref="AssemblyLoadContext.Default"/>

--- a/src/Plugins/PluginLoader.cs
+++ b/src/Plugins/PluginLoader.cs
@@ -379,6 +379,7 @@ namespace McMaster.NETCore.Plugins
             }
 #endif
 
+            builder.IsLazyLoaded(config.IsLazyLoaded);
             foreach (var assemblyName in config.SharedAssemblies)
             {
                 builder.PreferDefaultLoadContextAssembly(assemblyName);

--- a/src/Plugins/PluginLoader.cs
+++ b/src/Plugins/PluginLoader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -112,9 +113,15 @@ namespace McMaster.NETCore.Plugins
                     {
                         if (sharedTypes != null)
                         {
+                            var uniqueAssemblies = new HashSet<Assembly>();
                             foreach (var type in sharedTypes)
                             {
-                                config.SharedAssemblies.Add(type.Assembly.GetName());
+                                uniqueAssemblies.Add(type.Assembly);
+                            }
+
+                            foreach (var assembly in uniqueAssemblies)
+                            {
+                                config.SharedAssemblies.Add(assembly.GetName());
                             }
                         }
                         configure(config);

--- a/src/Plugins/PublicAPI.Shipped.txt
+++ b/src/Plugins/PublicAPI.Shipped.txt
@@ -15,6 +15,7 @@ McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.AssemblyLoadContextBu
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.Build() -> System.Runtime.Loader.AssemblyLoadContext
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.PreferDefaultLoadContext(bool preferDefaultLoadContext) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.ShadowCopyNativeLibraries() -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
+McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.IsLazyLoaded(bool isLazyLoaded) -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
 McMaster.NETCore.Plugins.Loader.DependencyContextExtensions
 McMaster.NETCore.Plugins.Loader.RuntimeConfigExtensions
 McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder.EnableUnloading() -> McMaster.NETCore.Plugins.Loader.AssemblyLoadContextBuilder
@@ -53,6 +54,8 @@ McMaster.NETCore.Plugins.PluginConfig.PreferSharedTypes.set -> void
 McMaster.NETCore.Plugins.PluginConfig.PrivateAssemblies.get -> System.Collections.Generic.ICollection<System.Reflection.AssemblyName>
 McMaster.NETCore.Plugins.PluginConfig.SharedAssemblies.get -> System.Collections.Generic.ICollection<System.Reflection.AssemblyName>
 McMaster.NETCore.Plugins.PluginConfig.SharedAssemblies.set -> void
+McMaster.NETCore.Plugins.PluginConfig.IsLazyLoaded.get -> bool
+McMaster.NETCore.Plugins.PluginConfig.IsLazyLoaded.set -> void
 McMaster.NETCore.Plugins.PluginLoader.Dispose() -> void
 McMaster.NETCore.Plugins.PluginLoader.IsUnloadable.get -> bool
 McMaster.NETCore.Plugins.PluginLoader.LoadAssemblyFromPath(string assemblyPath) -> System.Reflection.Assembly

--- a/test/Plugins.Tests/SharedTypesTests.cs
+++ b/test/Plugins.Tests/SharedTypesTests.cs
@@ -47,11 +47,18 @@ namespace McMaster.NETCore.Plugins.Tests
                     TestResources.GetTestProjectAssembly("TransitivePlugin"),
                     sharedTypes: new[] { typeof(SharedType) });
 
-            var assembly = loader.LoadDefaultAssembly();
-            var configType = assembly.GetType("TransitivePlugin.PluginConfig", throwOnError: true)!;
-            var config = Activator.CreateInstance(configType);
-            var transitiveInstance = configType.GetMethod("GetTransitiveType")?.Invoke(config, null);
-            Assert.IsType<Test.Transitive.TransitiveSharedType>(transitiveInstance);
+            TransitiveAssembliesOfSharedTypesAreResolvedBase(loader);
+        }
+
+        /// <summary>
+        /// Variant of <see cref="TransitiveAssembliesOfSharedTypesAreResolved"/> which uses lazy loading for assemblies.
+        /// </summary>
+        [Fact]
+        public void LazyLoadedTransitiveAssembliesOfSharedTypesAreResolved()
+        {
+            using var loader = PluginLoader.CreateFromAssemblyFile(TestResources.GetTestProjectAssembly("TransitivePlugin"), sharedTypes: new[] { typeof(SharedType) }, config => config.IsLazyLoaded = true);
+
+            TransitiveAssembliesOfSharedTypesAreResolvedBase(loader);
         }
 
         /// <summary>
@@ -101,6 +108,15 @@ namespace McMaster.NETCore.Plugins.Tests
 
             var callingContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly());
             Assert.True(config?.TryLoadPluginsInCustomContext(callingContext));
+        }
+
+        private void TransitiveAssembliesOfSharedTypesAreResolvedBase(PluginLoader loader)
+        {
+            var assembly = loader.LoadDefaultAssembly();
+            var configType = assembly.GetType("TransitivePlugin.PluginConfig", throwOnError: true)!;
+            var config = Activator.CreateInstance(configType);
+            var transitiveInstance = configType.GetMethod("GetTransitiveType")?.Invoke(config, null);
+            Assert.IsType<Test.Transitive.TransitiveSharedType>(transitiveInstance);
         }
     }
 }


### PR DESCRIPTION
## Problem

Hello, it's been a while since my last contribution https://github.com/natemcmaster/DotNetCorePlugins/pull/111 but I figured I'd swing around again.

Forever thirsty for performance, I've been trying to optimise startup times in my own application; not because it's strictly necessary but because I figured I can. Maybe it's just the perfectionist inside me.

After some investigation it occurred to me that startup has always been mostly I/O bottlenecked (as expected). After some minor experimentation, I figured that it is possible to partially work around that and came up with an idea to heavily reduce this bottleneck.

## Solution

Load dependencies of exported plugin assemblies lazily (just in time as they are needed!) rather than pre-loading them all ahead of time.

This PR adds an optional feature `IsLazyLoaded` in `PluginConfig` which achieves just that.
Relevant patches are made in `AssemblyLoadContextBuilder.PreferDefaultLoadContextAssembly` and `ManagedLoadContext.Load`.

## Use Cases

Main use case for this feature would be extracting small amounts of data from the plugins and/or loading many plugins at once. 

For the former, sometimes you might only want to extract a small snippet of embedded information and as such loading all dependencies is not necessary to do ahead of time.

For the latter, consider situations such as applications with 20, 40, 60, 80+ etc. plugins being cold loaded after a PC restart. On a conventional hard drive, we might be saving seconds here.

#### Example: UI Application & Configurable Plugins

Plugins might have an interface which can be used for exporting configurations. These configurations might then be edited using a generic interface such as a `PropertyGrid` in WinForms. 

Currently selecting an individual plugin (especially cold loads) in UI applications may cause a noticeable stutter/lag spike due to the aforementioned I/O bottleneck.

## Risks

The intended/main usage of the library, _host sharing a contract in the form of a known interface at compile time with the plugins_ should be unaffected by this optional feature. *There should not be any functional difference introduced by not loading ahead of time*.

Transitive dependencies may come to mind, specifically dependencies of the plugin that the host is also aware or has a copy of. These function just the same way as if they were loaded ahead of time; I added a test for this just in case.

I have not managed to identify any cases in which the introduction of this feature would break existing functionality.

## Tests

As for the test project; I wasn't really sure if this feature needed any special specific tests outside of ensuring transitive assemblies are still correctly resolved; so I added an additional variation of `TransitiveAssembliesOfSharedTypesAreResolved` in `SharedTypesTests` that uses the new setting to ensure correct resolution.

I also tested this on real software and a few random existing tests just in case (see below), everything seems to be working properly.

## Results (Real Software)

People tend to often showcase the best case scenario for changes; I figured I'd go the other way around and show the worst case scenario instead.

Notably; we are working around an I/O bottleneck here so the worst case condition is to perform a hot load (i.e. plugins are either cached by the OS in memory or by hardware). This was performed by loading 5 times in a row and taking the best time before and after.

**Before:**

![Tsonic_win_BvMawy50LV](https://user-images.githubusercontent.com/6697380/93027874-e4ad7b80-f607-11ea-9ca8-8c4b891e0cfc.png)

**After:** 

![Tsonic_win_4Mguj7CEgP](https://user-images.githubusercontent.com/6697380/93027886-f858e200-f607-11ea-8e8b-708c70fdd080.png)

This is [Reloaded II](https://github.com/Reloaded-Project/Reloaded-II), using a sample of 16 plugins.

Specifically benchmarked is the process described in https://github.com/natemcmaster/DotNetCorePlugins/issues/60#issuecomment-526008799 , where `Loading Assembly Metadata` refers to step 2 (for all plugins); and initialising refers to step 3; both performed in parallel to maximise performance (this is an I/O bottleneck after all).

Real world performance improvement for "worst case" tends to be in the range of 2.5x-3.0x considering the numbers also include finding the entry point etc. I haven't tested cold loads (best case scenario as this is an I/O bottleneck) but I'd expect the difference to be more significant.

**Edit:** 
I took a quick cold boot test after all. 
Total time saved for this highly optimised concurrent load scenario was 300ms, as opposed to 100ms in cold boot on a standard SATA 3 SSD.
Savings weren't as large as expected but still fairly noticeable nonetheless; especially when executing non-concurrently.

## Other Miscellaneous Changes (Performance)
- `PluginLoader.CreateFromAssemblyFile(string, Type[], Action<PluginConfig>)`

Instead of adding the assembly for each type, I considered that there are end users (unfamiliar to inner workings) who may pass multiple types belonging to the same assembly to the method. With that in mind, I made the library remove duplicates before they are added to `config.SharedAssemblies`.

The main reason for this is down the road, the loader will call `AssemblyLoadContextBuilder.PreferDefaultLoadContextAssembly`; this is an expensive operation when lazy loading is not enabled and it does not need to be executed multiple times with the same assembly name.