### PR TITLE
load pdb file if available for linenumbers in stacktrace

### DIFF
--- a/src/Plugins/Loader/ManagedLoadContext.cs
+++ b/src/Plugins/Loader/ManagedLoadContext.cs
@@ -192,7 +192,14 @@ namespace McMaster.NETCore.Plugins.Loader
             }
 
             using var file = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var pdbPath = Path.ChangeExtension(path, ".pdb");
+            if (File.Exists(pdbPath))
+            {
+                using var pdbFile = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                return LoadFromStream(file,pdbFile);
+            }
             return LoadFromStream(file);
+
         }
 
         /// <summary>

--- a/src/Plugins/Loader/ManagedLoadContext.cs
+++ b/src/Plugins/Loader/ManagedLoadContext.cs
@@ -196,7 +196,7 @@ namespace McMaster.NETCore.Plugins.Loader
             if (File.Exists(pdbPath))
             {
                 using var pdbFile = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-                return LoadFromStream(file,pdbFile);
+                return LoadFromStream(file, pdbFile);
             }
             return LoadFromStream(file);
 


### PR DESCRIPTION

if we want linenumbers in the stacktrace of a exception/Environment.StackTrace or StackTrace,GetFrame,... we have load the pdb files

changed method DotNetCorePlugins\src\Plugins\Loader\ManagedLoadContext.cs LoadAssemblyFromFilePath:187