### PR TITLE
Changed: Reduce .NET Runtime requirement to net5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: "6.0.x"
+      - name: Setup .NET 5
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: "5.0.x"
       - name: Run build script
         id: build_script
         run: ./build.ps1 -ci

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ assembly isolation and type sharing. Read [more details about type sharing below
 
 > **Note**
 >
-> 2.0+ of library supports .NET 6. If you still need .NET < 6 support, look for an old 1.* version of this library.
+> 2.0+ of library supports .NET 5. If you still need .NET < 5 support, look for an old 1.* version of this library.
 
 Blog post introducing this project, July 25, 2018: [.NET Core Plugins: Introducing an API for loading .dll files (and their dependencies) as 'plugins'](https://natemcmaster.com/blog/2018/07/25/netcore-plugins/).
 
@@ -75,7 +75,7 @@ There is nothing special about the name "IPlugin" or the fact that it's an inter
 
 > **Warning**
 >
-> Using `netstandard2.0` as the TargetFramework for your plugin project has known issues. Use `net6.0` instead.
+> Using `netstandard2.0` as the TargetFramework for your plugin project has known issues. Use `net5.0` instead.
 
 A minimal implementation of the plugin could be as simple as this.
 

--- a/samples/aspnetcore-mvc/MvcApp/MvcApp.csproj
+++ b/samples/aspnetcore-mvc/MvcApp/MvcApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aspnetcore-mvc/MvcAppPlugin1/MvcAppPlugin1.csproj
+++ b/samples/aspnetcore-mvc/MvcAppPlugin1/MvcAppPlugin1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/samples/aspnetcore/MainWebApp/MainWebApp.csproj
+++ b/samples/aspnetcore/MainWebApp/MainWebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dependency-injection/DI.HostApp/DI.HostApp.csproj
+++ b/samples/dependency-injection/DI.HostApp/DI.HostApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dynamic-implementation/Contracts/Contracts.csproj
+++ b/samples/dynamic-implementation/Contracts/Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/dynamic-implementation/Host/Host.csproj
+++ b/samples/dynamic-implementation/Host/Host.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/dynamic-implementation/Mixer/Mixer.csproj
+++ b/samples/dynamic-implementation/Mixer/Mixer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/samples/dynamic-implementation/ServiceImplementation/ServiceImplementation.csproj
+++ b/samples/dynamic-implementation/ServiceImplementation/ServiceImplementation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/hello-world/HostApp/HostApp.csproj
+++ b/samples/hello-world/HostApp/HostApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hot-reload/HotReloadApp/HotReloadApp.csproj
+++ b/samples/hot-reload/HotReloadApp/HotReloadApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hot-reload/TimestampedPlugin/TimestampedPlugin.csproj
+++ b/samples/hot-reload/TimestampedPlugin/TimestampedPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins.Mvc/McMaster.NETCore.Plugins.Mvc.csproj
+++ b/src/Plugins.Mvc/McMaster.NETCore.Plugins.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>library</OutputType>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Plugins/McMaster.NETCore.Plugins.csproj
+++ b/src/Plugins/McMaster.NETCore.Plugins.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>library</OutputType>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Plugins.Tests/McMaster.NETCore.Plugins.Tests.csproj
+++ b/test/Plugins.Tests/McMaster.NETCore.Plugins.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestResults\**</DefaultItemExcludes>
   </PropertyGroup>
 

--- a/test/TestProjects/Banana/Banana.csproj
+++ b/test/TestProjects/Banana/Banana.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test/TestProjects/DrawingApp/DrawingApp.csproj
+++ b/test/TestProjects/DrawingApp/DrawingApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestProjects/NativeDependency/NativeDependency.csproj
+++ b/test/TestProjects/NativeDependency/NativeDependency.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestProjects/NetCoreApp2App/NetCoreApp2App.csproj
+++ b/test/TestProjects/NetCoreApp2App/NetCoreApp2App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestProjects/Plátano/Plátano.csproj
+++ b/test/TestProjects/Plátano/Plátano.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test/TestProjects/PowerShellPlugin/PowerShellPlugin.csproj
+++ b/test/TestProjects/PowerShellPlugin/PowerShellPlugin.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.4" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.7" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SqlClientApp/SqlClientApp.csproj
+++ b/test/TestProjects/SqlClientApp/SqlClientApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/test/TestProjects/WithOwnPlugins/WithOwnPlugins.csproj
+++ b/test/TestProjects/WithOwnPlugins/WithOwnPlugins.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestProjects/WithOwnPluginsContract/WithOwnPluginsContract.csproj
+++ b/test/TestProjects/WithOwnPluginsContract/WithOwnPluginsContract.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Based on API availability, there isn't a good reason as to why we should prohibit the running of the library on `.NET 5`, even if the runtime itself is itself officially out of support as there isn't anything in the library that strictly requires `net6.0` or above. 

This PR restores support for the `net5.0` TFM and runtime in the library, including Unit Tests and CI/CD.

My previous PRs were much more elaborate; hopefully this one should be pretty trivial.
I'm personally stuck on .NET 5 in one of my projects due to a runtime issue in .NET 6 involving an optimisation that skips the Managed->Native transition during ICalls/FCalls. Thankfully it appears to have been fixed in .NET 7.

[A bit anticlimactic for PR #255, but it is what it is] 